### PR TITLE
fix calling initializations from non-main thread

### DIFF
--- a/Runtime/Any/Scripts/Initializations/MainInitialization.cs
+++ b/Runtime/Any/Scripts/Initializations/MainInitialization.cs
@@ -54,6 +54,8 @@ namespace Playbox
 
         public override void Initialization()
         {
+            Utils.MainThreadDispatcher.Init();
+
             if(Application.isPlaying)
                 DontDestroyOnLoad(gameObject);
             
@@ -103,6 +105,7 @@ namespace Playbox
             
             ConsentData.ShowConsent(this, b =>
             {
+                Utils.MainThreadDispatcher.Enqueue(() => {
                     foreach (var item in behaviours)
                     {
                         if (item != null)
@@ -111,6 +114,7 @@ namespace Playbox
                                     item.Initialization();
                         }
                     }
+                });
             });
             
             PostInitialization?.Invoke();

--- a/Runtime/Utils/MainThreadDispatcher.cs
+++ b/Runtime/Utils/MainThreadDispatcher.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Utils {
+    internal class MainThreadDispatcher : MonoBehaviour {
+        private static readonly object _queueLock = new object();
+        private static readonly List<Action> _queue = new List<Action>();
+        private static MainThreadDispatcher _instance;
+
+        internal static void Init() {
+            if (_instance != null) {
+                return;
+            }
+
+            GameObject go = new GameObject(nameof(MainThreadDispatcher));
+            DontDestroyOnLoad(go);
+            _instance = go.AddComponent<MainThreadDispatcher>();
+        }
+
+        internal static void Enqueue(Action action) {
+            if (action == null) {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            lock (_queueLock) {
+                _queue.Add(action);
+            }
+        }
+
+        private void Update() {
+            lock (_queueLock) {
+                foreach (Action action in _queue) {
+                    action();
+                }
+
+                _queue.Clear();
+            }
+        }
+    }
+}

--- a/Runtime/Utils/MainThreadDispatcher.cs.meta
+++ b/Runtime/Utils/MainThreadDispatcher.cs.meta
@@ -1,4 +1,4 @@
 fileFormatVersion: 2
-guid: 756d92b5151d47db8272ce77a328542e
+guid: f05e9e4c7de341d39b8598c3ce678a06
 timeCreated: 1751568254028
 

--- a/Runtime/Utils/MainThreadDispatcher.cs.meta
+++ b/Runtime/Utils/MainThreadDispatcher.cs.meta
@@ -1,0 +1,4 @@
+fileFormatVersion: 2
+guid: 756d92b5151d47db8272ce77a328542e
+timeCreated: 1751568254028
+


### PR DESCRIPTION
fixes exceptions like this one:

```
UnityException: Internal_CreateGameObject can only be called from the main thread.
Constructors and field initializers will be executed from the loading thread when loading a scene.
Don't use this function in the constructor or field initializers, instead move initialization code to the Awake or Start function.

AppLovinMax.Internal.MaxEventExecutor.InitializeIfNeeded () (at <00000000000000000000000000000000>:0)
MaxSdkAndroid..cctor () (at <00000000000000000000000000000000>:0)
...
```